### PR TITLE
Fix crash when the component is destroyed before the end of the anima…

### DIFF
--- a/index.js
+++ b/index.js
@@ -450,7 +450,7 @@ class SortableListView extends React.Component {
 
   componentDidMount() {
     InteractionManager.runAfterInteractions(() => {
-      this.timer = setTimeout(this.measureWrapper, 0)
+      this.timer = setTimeout(() => this && this.measureWrapper, 0)
     })
   }
 


### PR DESCRIPTION
…tion

You can reproduce the bug by switching between two screen (one of them containing the sortable listview) faster than the transition animation duration. The application crash saying: "cannot read property measureWrapper of undefined".

Thanks to @gouxlord